### PR TITLE
Add toContainObject matcher with type and Any support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   rules: {},
   globals: {
     expect: "readonly",
+    Any: "readonly",
     it: "readonly",
     describe: "readonly",
     beforeEach: "readonly",

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,6 +1,120 @@
 const chalk = require("chalk");
 const state = require("./state");
 
+/** Sentinel for matching any value in toContainObject. */
+const Any = Symbol("Any");
+
+const TYPE_MATCHERS = new Set([
+  Number,
+  String,
+  Boolean,
+  BigInt,
+  Symbol,
+  Function,
+  Object,
+  Array,
+  Date,
+  RegExp,
+  Map,
+  Set,
+  WeakMap,
+  WeakSet,
+]);
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isTypeMatcher(value) {
+  return value === Any || TYPE_MATCHERS.has(value);
+}
+
+/**
+ * @param {*} actual
+ * @param {*} matcher
+ * @returns {boolean}
+ */
+function matchType(actual, matcher) {
+  if (matcher === Any) return true;
+  if (matcher === Number) {
+    return typeof actual === "number" || actual instanceof Number;
+  }
+  if (matcher === String) {
+    return typeof actual === "string" || actual instanceof String;
+  }
+  if (matcher === Boolean) {
+    return typeof actual === "boolean" || actual instanceof Boolean;
+  }
+  if (matcher === BigInt) return typeof actual === "bigint";
+  if (matcher === Symbol) return typeof actual === "symbol";
+  if (matcher === Function) return typeof actual === "function";
+  if (matcher === Object) return typeof actual === "object" && actual !== null;
+  if (matcher === Array) return Array.isArray(actual);
+  if (matcher === Date) return actual instanceof Date;
+  if (matcher === RegExp) return actual instanceof RegExp;
+  if (matcher === Map) return actual instanceof Map;
+  if (matcher === Set) return actual instanceof Set;
+  if (matcher === WeakMap) return actual instanceof WeakMap;
+  if (matcher === WeakSet) return actual instanceof WeakSet;
+  return false;
+}
+
+/**
+ * Subset object match: every key in expected must exist on received with matching value or type.
+ * @param {*} received
+ * @param {*} expected
+ * @returns {boolean}
+ */
+function matchesPartialObject(received, expected) {
+  if (!isPlainObject(received) || !isPlainObject(expected)) {
+    return false;
+  }
+
+  for (const key of Object.keys(expected)) {
+    if (!Object.prototype.hasOwnProperty.call(received, key)) {
+      return false;
+    }
+
+    const expVal = expected[key];
+    const recVal = received[key];
+
+    if (isTypeMatcher(expVal)) {
+      if (!matchType(recVal, expVal)) return false;
+    } else if (isPlainObject(expVal)) {
+      if (!matchesPartialObject(recVal, expVal)) return false;
+    } else if (expVal !== recVal) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Safe string for assertion messages (BigInt, Symbol, type matchers).
+ * @param {*} value
+ * @returns {string}
+ */
+function formatForMessage(value) {
+  return JSON.stringify(value, (_, v) => {
+    if (typeof v === "bigint") return `${v}n`;
+    if (typeof v === "function") return v.name ? `[${v.name}]` : "[Function]";
+    if (typeof v === "symbol") {
+      if (v === Any) return "Any";
+      return v.toString();
+    }
+    return v;
+  });
+}
+
 /**
  * Parse the call stack to find the test file line for failure output.
  * @returns {string | undefined}
@@ -38,7 +152,7 @@ function recordFail(msg) {
 /**
  * Create a matcher object for the given value.
  * @param {*} value - Actual value under test.
- * @returns {object} Matcher with toBe, toEqual, toBeNull, toThrow, and .not.
+ * @returns {object} Matcher with toBe, toEqual, toBeNull, toThrow, toContainObject, and .not.
  */
 function expect(value) {
   return {
@@ -112,7 +226,19 @@ function expect(value) {
         );
       }
     },
+
+    /**
+     * Subset object match: expected keys must exist with matching literals or types.
+     * @param {object} expected
+     */
+    toContainObject(expected) {
+      const matched = matchesPartialObject(value, expected);
+      const pass = this.isNot ? !matched : matched;
+      const msg = `expect ${formatForMessage(value)} to contain object ${formatForMessage(expected)}`;
+      if (pass) recordPass(msg);
+      else recordFail(msg);
+    },
   };
 }
 
-module.exports = { expect };
+module.exports = { expect, Any };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const state = require("./state");
 const suite = require("./suite");
-const { expect } = require("./expect");
+const { expect, Any } = require("./expect");
 const { runSuites } = require("./run-test");
 const { showTestsResults } = require("./reporter");
 
@@ -12,6 +12,7 @@ function setupGlobals() {
   global.describe = suite.describe;
   global.it = suite.it;
   global.expect = expect;
+  global.Any = Any;
   global.beforeEach = suite.beforeEach;
   global.afterEach = suite.afterEach;
 }

--- a/test/expect-contain-object.test.js
+++ b/test/expect-contain-object.test.js
@@ -1,0 +1,76 @@
+describe("toContainObject", () => {
+  it("matches literal values", () => {
+    expect({ id: 1, name: "Alice" }).toContainObject({ id: 1, name: "Alice" });
+  });
+
+  it("matches primitive type matchers", () => {
+    expect({
+      num: 42,
+      str: "hi",
+      bool: true,
+      big: 10n,
+      sym: Symbol("x"),
+    }).toContainObject({
+      num: Number,
+      str: String,
+      bool: Boolean,
+      big: BigInt,
+      sym: Symbol,
+    });
+  });
+
+  it("matches Any for any value", () => {
+    expect({ id: 1, name: "Alice" }).toContainObject({ id: Any, name: Any });
+  });
+
+  it("matches nested object subsets", () => {
+    expect({ meta: { count: 3, label: "items" } }).toContainObject({
+      meta: { count: Number },
+    });
+  });
+
+  it("matches null and undefined literals", () => {
+    expect({ a: null, b: undefined }).toContainObject({
+      a: null,
+      b: undefined,
+    });
+  });
+
+  it("allows extra keys on received object", () => {
+    expect({ id: 1, extra: true }).toContainObject({ id: Number });
+  });
+
+  it("fails when key is missing", () => {
+    expect({ id: 1 }).not.toContainObject({ id: Number, name: String });
+  });
+
+  it("fails when type does not match", () => {
+    expect({ id: "1" }).not.toContainObject({ id: Number });
+  });
+
+  it("fails when literal does not match", () => {
+    expect({ id: 2 }).not.toContainObject({ id: 1 });
+  });
+
+  it("fails for non-object received value", () => {
+    expect(5).not.toContainObject({ id: Number });
+    expect(null).not.toContainObject({ id: Number });
+    expect([]).not.toContainObject({ id: Number });
+  });
+
+  it("matches built-in object types", () => {
+    expect({
+      arr: [1, 2],
+      date: new Date("2020-01-01"),
+      re: /abc/,
+      map: new Map(),
+      set: new Set(),
+    }).toContainObject({
+      arr: Array,
+      date: Date,
+      re: RegExp,
+      map: Map,
+      set: Set,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `expect(value).toContainObject(expected)` for subset object matching — received objects may have extra keys, but every key in `expected` must be present with a matching value.
- Supports literal values, nested objects, built-in type constructors (`Number`, `String`, `Array`, etc.), and the `Any` sentinel for wildcard matching.
- Exposes `Any` as a global (alongside `expect`, `describe`, `it`) and adds comprehensive tests in `test/expect-contain-object.test.js`.

## Test plan

- [ ] `npm run lint`
- [ ] `npm test` (new `expect-contain-object.test.js` cases should pass; known intentional failures in `test02` and `async` remain)

Made with [Cursor](https://cursor.com)